### PR TITLE
Remove failed tests from the result array, fixes #5

### DIFF
--- a/test/webpagetest.js
+++ b/test/webpagetest.js
@@ -455,7 +455,7 @@ suite('webpagetest:', function () {
                 webpagetest.getResults({
                     uri: 'foo',
                     key: 'bar',
-                    log: { info: nop, warn: nop, error: nop },
+                    log: { info: nop, warn: nop, error: nop }
                 }, [
                     { name: 'a', url: 'b', type: 'away', label: 'c', id: 'd' },
                     { name: 'e', url: 'f', type: 'home', label: 'g', id: 'h' }


### PR DESCRIPTION
Failed tests were causing charts to display wrong, leaving empty gaps and causing multiple labels to be printed at the same offset. This change removes failed tests from the result array entirely, which fixes those issues.