### PR TITLE
Changing supported engines from io.js to node 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - "4.0"
   - "0.12"
   - "0.10"
-  - "iojs"
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ with the command `npm test`.
 
 ## What versions of node.js does it support?
 
-0.10, 0.12, latest stable io.js
+0.10 - 4.0
 
 ## What license is it released under?
 


### PR DESCRIPTION
Because Node and io.js have now united into one engine