### PR TITLE
Cease support for node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "4.0"
   - "0.12"
-  - "0.10"
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ with the command `npm test`.
 
 ## What versions of node.js does it support?
 
-0.10 - 4.0
+0.12 or greater
 
 ## What license is it released under?
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
         "webpagetest": "0.3.x",
         "get-off-my-log": "0.1.x",
         "handlebars": "3.0.x",
-        "es6-promise": "2.0.x",
         "jszip": "2.4.x",
         "bfj": "1.1.x"
     },

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,6 @@
 
 var bfj, path, normalise, get, wpt;
 
-require('es6-promise').polyfill();
 bfj = require('bfj');
 path = require('path');
 normalise = require('./options').normalise;

--- a/test/index.js
+++ b/test/index.js
@@ -26,7 +26,6 @@ spooks = require('spooks');
 modulePath = '../src/index';
 
 mockery.registerAllowable(modulePath);
-mockery.registerAllowable('es6-promise');
 
 suite('index:', function () {
     var log, results;

--- a/test/webpagetest.js
+++ b/test/webpagetest.js
@@ -22,7 +22,6 @@ var assert, mockery, spooks, modulePath;
 assert = require('chai').assert;
 mockery = require('mockery');
 spooks = require('spooks');
-require('es6-promise').polyfill();
 
 modulePath = '../src/webpagetest';
 


### PR DESCRIPTION
A few things here:

1. BFJ only supports node.js 0.12+, causing webpagetest-mapper to crash when dumping results or reading dumped results in 0.10.

2. I removed the `... - 4.0` part of the supported versions documentation, because it's a lie (4.1 is fine too) and simply saying `... or greater` is a lesser maintenance burden.

3. I removed the `es6-promise` dependency because it was only in there for 0.10 support.